### PR TITLE
Fix case in require "xp11DATAlookups"

### DIFF
--- a/xp11out.lua
+++ b/xp11out.lua
@@ -10,7 +10,7 @@ set_plugin_info(xp11out_info)
 
 --local d = require('debug')
 require "xp11lookups"
-require "xp11Datalookups"
+require "xp11DATAlookups"
 
 xp11out = Proto("xp11out","X-Plane 11 (Out)")
 xp11out.fields.header= ProtoField.string("xp11out.header", "Header")


### PR DESCRIPTION
Hi!
Thanks for this dissector, it really made it easier to look at X-Plane packets.
Here is a very small fix that makes it work on Linux where filenames are case-sensitive.